### PR TITLE
Adding -a/--all to check all processes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Supervisord-Nagios-Plugin
 Instalation
 -----------
 
-Copy the file check_supv.py to your Nagios/Icinga directory and make executable 
+Copy the file check_supv.py to your Nagios/Icinga directory and make executable
 
 
 Configuration
@@ -24,4 +24,14 @@ Run the command with the name of the supervisord process as it appears in ``supe
 ::
 
         check_supv -p PROCESS_NAME
+        check_supv --processes-name PROCESS_NAME
 
+To check all processes declared and listed in ``supervisorctl status``
+
+::
+
+        check_supv -a
+        check_supv --all
+
+
+Note: -p/--processes-name and -a/--all are mutually exclusive

--- a/check_supv.py
+++ b/check_supv.py
@@ -13,6 +13,7 @@ usage
 """
 import argparse
 import os
+import sys
 
 #nagios return codes
 UNKNOWN = -1
@@ -43,15 +44,56 @@ def get_status(proc_name):
         print "CRITICAL: Could not get status of %s" % proc_name
         raise SystemExit, CRITICAL
 
+def check_all():
+    try:
+        process_list = os.popen('%s' % SUPERV_STAT_CHECK).readlines()
+    except:
+        print "CRITICAL: Could not run %s" % (SUPERV_STAT_CHECK,)
+        raise SystemExit, UNKNOWN
+
+    worst_return_code = OK
+    processes_in_error = []
+    for process_line in process_list:
+        process_name = process_line.split()[0]
+        process_output, process_status = get_status(process_name)
+        if process_status > worst_return_code:
+            worst_return_code = process_status
+            processes_in_error.append((process_output, process_status),)
+
+    if worst_return_code == OK:
+        print "All processes are OK"
+        raise SystemExit, OK
+
+    if processes_in_error:
+        p = []
+        for process_error in processes_in_error:
+            lineTokens = process_error[0].split()
+            msg = "%s (%s)" % (lineTokens[0], lineTokens[1])
+            p.append(msg)
+        print "Processes in error: %s" % (', '.join(p))
+        raise SystemExit, worst_return_code
+
+
 parser = argparse.ArgumentParser()
-parser.add_argument('-p', '--processes-name', dest='process_name',
+
+group = parser.add_mutually_exclusive_group(required = True)
+group.add_argument('-p', '--processes-name', dest='process_name',
     help="Name of process as it appears in supervisorctl status")
+group.add_argument('-a', '--all', action="store_true",
+    help="List all processes and check them")
+
 parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
     default=False)
 parser.add_argument('-q', '--quiet', dest='verbose', action='store_false')
 
 args = parser.parse_args()
 
-output = get_status(args.process_name)
-print output[0]
-raise SystemExit, output[1]
+if args.all:
+    check_all()
+elif args.process_name:
+    output = get_status(args.process_name)
+    print output[0]
+    raise SystemExit, output[1]
+else:
+    print "Unknow command"
+    sys.exit(0)

--- a/check_supv.py
+++ b/check_supv.py
@@ -82,10 +82,6 @@ group.add_argument('-p', '--processes-name', dest='process_name',
 group.add_argument('-a', '--all', action="store_true",
     help="List all processes and check them")
 
-parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
-    default=False)
-parser.add_argument('-q', '--quiet', dest='verbose', action='store_false')
-
 args = parser.parse_args()
 
 if args.all:

--- a/check_supv.py
+++ b/check_supv.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 """
-nagios plugin to monitor indivdual supervisor processes
--------------------------------------------------------
+nagios plugin to monitor indivdual/all supervisor processes
+-----------------------------------------------------------
 
-usage
+usage, to check a single process
 
 ::
 
     check_supv -p PROCESS_NAME
+
+usage, to check all declared processes
+
+::
+
+    check_supv -a
 
 
 """

--- a/check_supv.py
+++ b/check_supv.py
@@ -11,7 +11,7 @@ usage
 
 
 """
-from optparse import OptionParser
+import argparse
 import os
 
 #nagios return codes
@@ -32,7 +32,7 @@ supervisor_states = {
     'BACKOFF': CRITICAL,
     'FATAL': CRITICAL,
     'UNKNOWN': CRITICAL
-    }
+}
 
 def get_status(proc_name):
     try:
@@ -43,15 +43,15 @@ def get_status(proc_name):
         print "CRITICAL: Could not get status of %s" % proc_name
         raise SystemExit, CRITICAL
 
-parser = OptionParser()
-parser.add_option('-p', '--processes-name', dest='proc_name',
+parser = argparse.ArgumentParser()
+parser.add_argument('-p', '--processes-name', dest='process_name',
     help="Name of process as it appears in supervisorctl status")
-parser.add_option('-v', '--verbose', dest='verbose', action='store_true',
+parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
     default=False)
-parser.add_option('-q', '--quiet', dest='verbose', action='store_false')
+parser.add_argument('-q', '--quiet', dest='verbose', action='store_false')
 
-options, args = parser.parse_args()
+args = parser.parse_args()
 
-output = get_status(options.proc_name)
+output = get_status(args.process_name)
 print output[0]
 raise SystemExit, output[1]


### PR DESCRIPTION
Hi,

Here is an enhanced version of the check_all branch.

This modification add an option to check all processes.
This keeps the -p option, for more flexibility.

This includes :
- Converting optparse to argparse as optparse is deprecated since python 2.7
- Updated documentation
- Remove -q/-v as they are unused
